### PR TITLE
Fixing issue where the tabs were not loading in monitor infra on firefox.

### DIFF
--- a/webroot/monitor/infra/js/monitor_infra_analyticnode.js
+++ b/webroot/monitor/infra/js/monitor_infra_analyticnode.js
@@ -706,7 +706,7 @@ analyticsNodeView = function () {
             $("#analytics_tabstrip").contrailTabs({
                 activate:function (e, ui) {
                     infraMonitorView.clearTimers();
-                    var selTab = ui.newTab.context.innerText;
+                    var selTab = $(ui.newTab.context).text();
                     if (selTab == 'Generators') {
                         populateGeneratorsTab(aNodeInfo);
                         $('#gridGenerators').data('contrailGrid').refreshView();

--- a/webroot/monitor/infra/js/monitor_infra_computenode.js
+++ b/webroot/monitor/infra/js/monitor_infra_computenode.js
@@ -2286,7 +2286,7 @@ computeNodeView = function () {
                  activate: function(e, ui) {
                     infraMonitorView.clearTimers();
                     //var selTab = $(e.item).text();
-                    var selTab = ui.newTab.context.innerText;
+                    var selTab = $(ui.newTab.context).text();
                     if (selTab != 'Console') {
                     }
 

--- a/webroot/monitor/infra/js/monitor_infra_confignode.js
+++ b/webroot/monitor/infra/js/monitor_infra_confignode.js
@@ -418,7 +418,7 @@ configNodeView = function () {
             $("#config_tabstrip").contrailTabs({
                 activate:function (e, ui) {
                     infraMonitorView.clearTimers();
-                    var selTab = ui.newTab.context.innerText;
+                    var selTab = $(ui.newTab.context).text();
                     if (selTab == 'Console') {
                         infraMonitorView.populateMessagesTab('config', {source:confNodeInfo['name']}, confNodeInfo);
                     } else if (selTab == 'Details') {

--- a/webroot/monitor/infra/js/monitor_infra_controlnode.js
+++ b/webroot/monitor/infra/js/monitor_infra_controlnode.js
@@ -1081,7 +1081,7 @@ controlNodeView = function () {
 //                },
                 activate:function (e, ui) {
                     infraMonitorView.clearTimers();
-                    var selTab = ui.newTab.context.innerText;
+                    var selTab = $(ui.newTab.context).text();
                     if (selTab == 'Peers') {
                         populatePeersTab(ctrlNodeInfo);
                         $('#gridPeers').data('contrailGrid').refreshView();


### PR DESCRIPTION
context.innerText is not supported by firefox replacing with the
.text().
