### PR TITLE
Fixed a bug.

### DIFF
--- a/webroot/config/networkpolicies/js/policy_config.js
+++ b/webroot/config/networkpolicies/js/policy_config.js
@@ -451,8 +451,9 @@ function initActions() {
                                 rule["src_ports"][j]["start_port"] = parseInt(startPortsArray[j]);
                                 rule["src_ports"][j]["end_port"] = parseInt(endPortsArray[j]);
                             }
+                        } else {
+                            return false;
                         }
-
                     } else
                         return false;
                 } else {
@@ -480,6 +481,8 @@ function initActions() {
                                 rule["dst_ports"][j]["start_port"] = parseInt(startPortsArray[j]);
                                 rule["dst_ports"][j]["end_port"] = parseInt(endPortsArray[j]);
                             }
+                        } else {
+                            return false;
                         }
                     } else
                         return false;


### PR DESCRIPTION
In Policy page when the rule is created with wrong port number it was creating
the policy and showing the error message.
Now showing the error message but not creating the policy.
