### PR TITLE
Floating IP changes wrt change in schema. Earlier FIP used to have VMI a...

### DIFF
--- a/webroot/config/vn/api/vnconfig.api.js
+++ b/webroot/config/vn/api/vnconfig.api.js
@@ -1870,6 +1870,7 @@ function instanceIPRefAggCb(error, instanceIPList, response, vmList, appData)
 	}
 	for(var i=0; i<instanceIPList.length; i++) {
 		vmList[i]["instance_ip_address"] = instanceIPList[i]["instance-ip"]["instance_ip_address"]; 
+                vmList[i]["instance_uuid"] = instanceIPList[i]["instance-ip"]["uuid"]; 
 	}
 	commonUtils.handleJSONResponse(error, response,
 		{'virtual_machine_interface_back_refs': vmList});


### PR DESCRIPTION
...nd VM UUIDs in same object which is now split. Changes are made to get the instance_ip_address, instance_ip_uuid appropriately.
The following UT has been performed.
Launch 'Allocate Floating IP' page
1) No floating IPs displayed. (Success)
2) 5 Floating IPs have been allocated from a FIPool:VN (Success)
3) Shows list of FIPs in the landing page. (Instance column is '-' for all floating ips) (Success)
4) Associate a floating ip to an instance (Commit success)
5) Shows list of FIPs in the landing page. Instance column is 'UUID_Of_Instance' for the associated floating ip. '-' for all other floating ips (Success)
6) Repeat step 4 for all other floating ips. All success.
7) Disassociate a floating ip from instance. (commit success)
8) Shows list of FIPs in the landing page. Instance column is - for the disassociated floating ip. 'UUID_Of_Instance' for all other floating ips (Success)
9) Repeat step 7 for all floating ips. 
10) Shows list of FIPs in the landing page. (Instance column is '-' for all floating ips) (Success)
11) Release a floating ip using 'Disassociate' action on row of the grid.
12) Released floating ip is not shown in the grid(success)
13) Release other floating ips using 'Disassociate' icon which is on top of grid. No floating IPs displayed on landing page. (Success)
