### PR TITLE
Fixed...Bug ID 1328785

### DIFF
--- a/webroot/config/fip/ui/js/fip_config.js
+++ b/webroot/config/fip/ui/js/fip_config.js
@@ -462,7 +462,6 @@ function showFIPEditWindow(mode) {
         $("#btnCreatefipOK").attr("disabled","disabled");
         var selectedProject = $("#ddProjectSwitcher").data("contrailDropdown").value();
         $("#ddFipPool").data("contrailDropdown").setData({text:'Floating IPs not allocated for the project.',value:""});
-        //$("#ddFipPool").data("contrailDropdown").text('floating IPs not allocated for this project.');
         $("#ddFipPool").data("contrailDropdown").enable(false);
 			
         var getAjaxs = [];
@@ -532,7 +531,13 @@ function fipAssociateWindow(rowIndex) {
             }
             if(vmi && vmi.length > 0) {
                 ddAssociate.data("contrailDropdown").setData(vmi);
-                ddAssociate.data("contrailDropdown").value(vmi[0]);
+                ddAssociate.data("contrailDropdown").value(vmi[0].value);
+                $("#btnAssociatePopupOK").attr("disabled",false);
+                $("#ddAssociate").data("contrailDropdown").enable(true);
+            } else {
+                $("#ddAssociate").data("contrailDropdown").setData({text:'No Instance found for the project.',value:""});
+                $("#ddAssociate").data("contrailDropdown").enable(false);
+                $("#btnAssociatePopupOK").attr("disabled","disabled");
             }
             windowAssociate.find('.modal-header-title').text("Associate Floating IP");
             var selectedRow = $("#gridfip").data("contrailGrid")._dataView.getItem(rowIndex);

--- a/webroot/config/fip/ui/views/fip_config.view
+++ b/webroot/config/fip/ui/views/fip_config.view
@@ -27,7 +27,7 @@
   	</div>
 </div>
 
-<div id="windowAssociate" class="modal modal-420 hide" tabindex="-1">
+<div id="windowAssociate" class="modal modal-560 hide" tabindex="-1">
 	<div class="modal-header">
 		<button type="button" class="close" data-dismiss="modal" aria-hidden="true"><i class="icon-remove"></i></button>
 	    <h6 class="modal-header-title"></h6>
@@ -38,7 +38,7 @@
 	            <label class="control-label" class="span3">Instance</label>
 	            <div class="controls">
 	            	<div class="row-fluid">
-		                <div class="span10 pull-left" id="ddAssociate" ></div>
+		                <div class="span11 pull-left" id="ddAssociate" ></div>
 		            </div>
 	            </div>
 	        </div>       


### PR DESCRIPTION
FIP page Associate is letting to save if there is no instance.
Test case.
Create a FIP pool and create a floating ip.
once there is some fip try associate from the menu in grid row menu.
The pop up will not have any instance but save will be enabled.
Fixed that.
