### PR TITLE
On behalf of Sagar.

### DIFF
--- a/webroot/reports/js/flow_queries.js
+++ b/webroot/reports/js/flow_queries.js
@@ -339,11 +339,11 @@ function addFSFilter() {
 };
 
 function runFSQuery() {
-    var serverCurrentTime;
+    var serverCurrentTime = getCurrentTime4MemCPUCharts();
     $.ajax({
-        url: '/api/admin/current-time'
+        url: '/api/service/networking/web-server-info'
     }).done(function (resultJSON) {
-        serverCurrentTime = resultJSON['currentTime'];
+        serverCurrentTime = resultJSON['serverUTCTime'];
     }).always(function() {
         runFSQueryCB(serverCurrentTime)
     });


### PR DESCRIPTION
'/api/admin/current-time' request handler had been removed during restructuring.
It has been replaced with existing handler -
'/api/service/networking/web-server-info'.
