### PR TITLE
Fix the firfox scroll bar reset issue in bgp peer page

### DIFF
--- a/webroot/config/bgp/ui/js/bgp_config.js
+++ b/webroot/config/bgp/ui/js/bgp_config.js
@@ -837,12 +837,12 @@ function btnaddbgpClick() {
     $('#msbgppeer').data('contrail2WayMultiselect').setLeftData(bgpavailabledata);
     mode = "add";
     bgpwindow.modal('show');
-    bgpwindow.find('.modal-body').scrollTop(0);
     bgpwindow.find('h6').text("Create BGP Peer");
     $("#txtasn").val(ggasn);
     $("#txtport").val("179");
     $("#chkextern").click();
-    $("#txtname").focus();    
+    $("#txtname").focus();  
+    bgpwindow.find('.modal-body').scrollTop(0);    
 }
 
 function initActions() {


### PR DESCRIPTION
Below test cases are verified

1)Click on Create BGP Peer and Verify the scroll position in the popup in firefox
2)Click on Create BGP Peer and Verify the scroll position in the popup in chrome
3)Click on Create BGP Peer and Verify the scroll position in the popup in IE9/10
