### PR TITLE
In Service Template create window Advance option was not scrolling.

### DIFF
--- a/webroot/config/services/template/ui/views/svctemplate_config.view
+++ b/webroot/config/services/template/ui/views/svctemplate_config.view
@@ -111,7 +111,7 @@ padding-top:25px;
             </div>
                 <div id="widgetStaticRoutes" class="widget-box transparent collapsed span5">
                     <div class="widget-header">
-                        <h5 class="smaller" onclick="collapseElement(this);">
+                        <h5 class="smaller" onclick="scrollUp('#windowCreateStemp',this,true);">
                             <i class="icon-caret-right grey" ></i>
                             <span>Advanced options</span>
                         </h5>


### PR DESCRIPTION
In Service Template create window Advance option was not scrolling. Fixed it.
Test case:
In Service Template page.
Click Add Service template button.
In The create window 
- Add Some Interface.
- Then click Advance option it was not scrolling (Fixed it)
