### PR TITLE
Fixed the wrong message issue in link local service's landing page.

### DIFF
--- a/webroot/config/linklocalservices/ui/js/lls_config.js
+++ b/webroot/config/linklocalservices/ui/js/lls_config.js
@@ -333,8 +333,8 @@ function handleCommitFailure(result) {
 }
 
 function fetchData() {
-    $("#gridLLS").data("contrailGrid").showGridMessage("loading");
     $("#gridLLS").data("contrailGrid")._dataView.setData([]);
+    $("#gridLLS").data("contrailGrid").showGridMessage("loading");
     doAjaxCall(
            "/api/tenants/config/global-vrouter-config", "GET",
         null, "populateData", "failureHandlerForGridLLS", null, null);


### PR DESCRIPTION
Tested below Scenarios
1)Verify the grid message when creating the new Link local service
2)Verify the grid message when Editing   Link local service
