### PR TITLE
As service-chain UVE format has been changed containg fqName to UUID, so...

### DIFF
--- a/webroot/monitor/tenant-network/api/network.mon.api.js
+++ b/webroot/monitor/tenant-network/api/network.mon.api.js
@@ -2054,7 +2054,7 @@ function getNetworkTreeTopology (req, res, appData)
 
     commonUtils.createReqObj(dataObjArr, reqUrl, global.HTTP_REQUEST_GET,
                              null, opApiServer, null, appData);
-    reqUrl = '/analytics/service-chain/*' + fqName + '*';
+    reqUrl = '/analytics/service-chain/*';
     commonUtils.createReqObj(dataObjArr, reqUrl, global.HTTP_REQUEST_GET,
                              null, opApiServer, null, appData);
     reqUrl = '/virtual-networks';


### PR DESCRIPTION
... now

send bulk service chain UVE request to build the topology.
