### PR TITLE
Integrated analytics Oracle stats changes in UI,bug id is #1350680

### DIFF
--- a/webroot/common/api/flowCache.api.js
+++ b/webroot/common/api/flowCache.api.js
@@ -26,6 +26,16 @@ if (!module.parent) {
 	process.exit(1);
 }
 
+var STATS_PROP = {
+                    'vn': {'inBytes':'SUM(vn_stats.in_bytes)','outBytes':'SUM(vn_stats.out_bytes)','inPkts':'SUM(vn_stats.in_pkts)',
+                            'outPkts':'SUM(vn_stats.out_pkts)'},
+                    'conn-vn': {'inBytes':'SUM(vn_stats.in_bytes)','outBytes':'SUM(vn_stats.out_bytes)','inPkts':'SUM(vn_stats.in_pkts)',
+                                'outPkts':'SUM(vn_stats.out_pkts)'},
+                    'vm': {'inBytes':'SUM(if_stats.in_bytes)','outBytes':'SUM(if_stats.out_bytes)','inPkts':'SUM(if_stats.in_pkts)',
+                            'outPkts':'SUM(if_stats.out_pkts)'},
+                    'fip' : {'inBytes':'SUM(fip_stats.in_bytes)','outBytes':'SUM(fip_stats.out_bytes)','inPkts':'SUM(fip_stats.in_pkts)',
+                            'outPkts':'SUM(fip_stats.out_pkts)'},
+                 };
 var FLOW_SERIES_CACHE_EXPIRY_TIME = 10 * 60; /* 10 Minutes */
 
 // Instantiate config and ops server access objects.
@@ -36,7 +46,7 @@ opServer = rest.getAPIServer({apiName:global.label.OPS_API_SERVER,
 flowCache = module.exports;
 
 function getFlowSeriesDataByAPIServer (context, appData, timeObj, srcQueryJSON,
-                                       destQueryJSON, callback)
+                                       destQueryJSON, callback,type)
 {
     var resultJSON = {};
     var timeGran = timeObj['timeGran'];
@@ -47,7 +57,11 @@ function getFlowSeriesDataByAPIServer (context, appData, timeObj, srcQueryJSON,
         if ((data != null) && data.length) {
             //logutils.logger.debug("Getting Query Response as:" +
              //                     JSON.stringify(data));
-            resultJSON = parseFlowSeriesData(data, timeObj);
+            if (global.STAT_TYPE == type) {
+                resultJSON = parseFlowSeriesDataForOracleStats(data, timeObj,context);
+            } else {
+                resultJSON = parseFlowSeriesData(data, timeObj);
+            }
             /* Cache saving should be done in caller */
         } 
         callback(err, resultJSON);
@@ -168,7 +182,44 @@ function parseFlowSeriesData (data, timeObj)
     results['flow-series'] = resultJSON;
     return results;
 }
-
+/*
+ * Function used to parse the stats oracle response for both virtual network and virtual machine
+ */
+function parseFlowSeriesDataForOracleStats(data, timeObj,context) {
+    var resultJSON = [];
+    var results = {};
+    var statsLen,stats;
+    var props = STATS_PROP[context];
+    try {
+        stats = data[0]['value'];
+        statsLen = stats.length;
+    } catch(e) {
+        stats = [];
+        statsLen = 0;
+    }
+    for (var i = 0; i < statsLen; i++) {
+        var obj = {};
+        obj['time'] = stats[i]['T='];
+        obj['inBytes'] = stats[i][props['inBytes']] != null ? stats[i][props['inBytes']] : 0;
+        obj['outBytes'] = stats[i][props['outBytes']] != null ? stats[i][props['outBytes']] : 0;
+        obj['inPkts'] = stats[i][props['inPkts']] != null ? stats[i][props['inPkts']] : 0;
+        obj['outPkts'] = stats[i][props['outPkts']] != null ? stats[i][props['outPkts']] : 0;
+        obj['totalPkts'] = obj['inPkts'] + obj['outPkts'];
+        obj['totalBytes'] = obj['inBytes'] + obj['outBytes'];
+        resultJSON[i] = obj;
+    }
+    /* Now Sort the data */
+    var totCnt = resultJSON.length;
+    resultJSON.sort(sortFlowSeriesDataByTS);
+    results['summary'] = {};
+    results['summary']['start_time'] = timeObj['start_time'];
+    results['summary']['end_time'] = timeObj['end_time'];
+    results['summary']['timeGran_microsecs'] =
+        Math.floor(parseInt(timeObj['timeGran'])) * global.MILLISEC_IN_SEC *
+        global.MICROSECS_IN_MILL;
+    results['flow-series'] = resultJSON;
+    return results;
+}
 function updateFlowSeriesQueryTimeGran (query, timeGran)
 {
     var selectQuery = query['select_fields'];
@@ -187,6 +238,8 @@ function updateFlowSeriesQueryTimeGran (query, timeGran)
 
 function updateFlowSeriesQueryStartEndTime (query, startTime, endTime)
 {
+    if (null == query)
+        return;
     query['start_time'] = startTime;
     query['end_time'] = endTime;
 }
@@ -537,7 +590,7 @@ function getFlowSeriesDataByStartEndTime (context, appData, srcQueryJSON,
 }
 
 function getFlowSeriesData (context, appData, srcQueryJSON, destQueryJSON,
-                            callback) 
+                            callback,type) 
 {
     var timeObj = nwMonUtils.createTimeObjByAppData(appData);
     var redisKey = getFlowSeriesRedisKey(context, appData);
@@ -546,7 +599,6 @@ function getFlowSeriesData (context, appData, srcQueryJSON, destQueryJSON,
         appData['relStartTime'] = parseInt(appData['relStartTime']);
         appData['relEndTime'] = parseInt(appData['relEndTime']);
     }
-
     updateFlowSeriesQueryStartEndTime(srcQueryJSON, timeObj['start_time'],
                                       timeObj['end_time']);
     updateFlowSeriesQueryStartEndTime(destQueryJSON, timeObj['start_time'],
@@ -554,7 +606,7 @@ function getFlowSeriesData (context, appData, srcQueryJSON, destQueryJSON,
     /* Check if the request consists of startTime and endTime */
     if (appData['relStartTime'] != null) {
         getFlowSeriesDataByStartEndTime(context, appData, srcQueryJSON,
-                                        destQueryJSON, callback);
+                                        destQueryJSON, callback,type);
         return;
     }
     /* First check if we have entry for this */
@@ -569,7 +621,7 @@ function getFlowSeriesData (context, appData, srcQueryJSON, destQueryJSON,
                                           function(err, flowData) {
                     callback(err, flowData);
                 });
-            });
+            },type);
         } else {
             /* Now check the time when we have the cache */
             getFlowSeriesDataByCache(context, appData, JSON.parse(jsonData), srcQueryJSON,

--- a/webroot/common/api/global.js
+++ b/webroot/common/api/global.js
@@ -12,6 +12,6 @@ global.STR_GET_SCHEMA_FLOW_SERIES = 'getSchemaCPULoadFlowSeries';
 global.STR_GET_COLLECTOR_CPU_FLOW_SERIES = 'getCollectorCPULoadFlowSeries';
 global.STR_GET_QE_CPU_FLOW_SERIES = 'getQECPULoadFlowSeries';
 global.STR_GET_OPS_CPU_FLOW_SERIES = 'getOpServerCPULoadFlowSeries';
-
+global.STAT_TYPE = 'oracleStats'
 module.exports = global;
 

--- a/webroot/common/api/nwMon.utils.js
+++ b/webroot/common/api/nwMon.utils.js
@@ -79,14 +79,18 @@ function createTimeObj (appData)
 function getStatDataByQueryJSON (srcQueryJSON, destQueryJSON, callback)
 {
     var dataObjArr = [];
-    commonUtils.createReqObj(dataObjArr, global.RUN_QUERY_URL,
-                             global.HTTP_REQUEST_POST,
-                             commonUtils.cloneObj(srcQueryJSON));
-    commonUtils.createReqObj(dataObjArr, global.RUN_QUERY_URL,
-                             global.HTTP_REQUEST_POST,
-                             commonUtils.cloneObj(destQueryJSON));
-    logutils.logger.debug("Query1 executing: " + JSON.stringify(dataObjArr[0]['data']));
-    logutils.logger.debug("Query2 executing:" + JSON.stringify(dataObjArr[1]['data']));
+    if (srcQueryJSON != null) {
+        commonUtils.createReqObj(dataObjArr, global.RUN_QUERY_URL,
+                                global.HTTP_REQUEST_POST,
+                                commonUtils.cloneObj(srcQueryJSON));
+    }
+    if (destQueryJSON != null) {
+        commonUtils.createReqObj(dataObjArr, global.RUN_QUERY_URL,
+                                global.HTTP_REQUEST_POST,
+                                commonUtils.cloneObj(destQueryJSON));
+    }
+    logutils.logger.debug("Query1 executing:" + JSON.stringify((dataObjArr[0] != null) ? dataObjArr[0]['data'] : ""));
+    logutils.logger.debug("Query2 executing:" + JSON.stringify((dataObjArr[1] != null) ? dataObjArr[1]['data'] : ""));
     async.map(dataObjArr, commonUtils.getServerRespByRestApi(opServer, true),
               function(err, data) {
         callback(err, data);

--- a/webroot/monitor/tenant-network/common/ui/js/tenant_monitor_topology.js
+++ b/webroot/monitor/tenant-network/common/ui/js/tenant_monitor_topology.js
@@ -105,6 +105,10 @@ function topologyRenderer() {
                         configData['out_bytes'] = formatBytes(nodes[i]['more_attr']['out_bytes']);
                         configData['out_tpkts'] = ifNull(nodes[i]['more_attr']['out_tpkts'],'-');
                         configData['in_tpkts'] = ifNull(nodes[i]['more_attr']['in_tpkts'],'-');
+                        configData['latest_in_bytes'] = formatBytes(nodes[i]['more_attr']['latest_in_bytes']);
+                        configData['latest_out_bytes'] = formatBytes(nodes[i]['more_attr']['latest_out_bytes']);
+                        configData['latest_out_tpkts'] = ifNull(nodes[i]['more_attr']['latest_out_tpkts'],'-');
+                        configData['latest_in_tpkts'] = ifNull(nodes[i]['more_attr']['latest_in_tpkts'],'-');
                     }
                     if(nodes[i]['node_type'] == 'service-instance'){
                         var siData=ifNull(jsonPath(response,'$..service-instances')[0],[]);

--- a/webroot/monitor/tenant-network/common/ui/js/tenant_monitor_utils.js
+++ b/webroot/monitor/tenant-network/common/ui/js/tenant_monitor_utils.js
@@ -7,7 +7,7 @@ var durationStr = ' (last 30 mins)';
 var durationTitle = 'Last 30 mins';
 var FLOW_QUERY_TIMEOUT = 310000;
 var TOP_IN_LAST_MINS = 10;
-var NUM_DATA_POINTS_FOR_FLOW_SERIES = 240;
+var NUM_DATA_POINTS_FOR_FLOW_SERIES = 120;
 
 function ObjectListView() {
     //Context & type 
@@ -53,7 +53,7 @@ function ObjectListView() {
                 minWidth: 150
             },{
                 field:'inBytes',
-                name:'Traffic (In/Out)',
+                name:'Traffic (In/Out) <br/> (Last 1 hr)',
                 minWidth:150,
                 formatter:function(r,c,v,cd,dc) {
                     return contrail.format("{0} / {1}",formatBytes(dc['inBytes']),formatBytes(dc['outBytes']));
@@ -160,7 +160,7 @@ function ObjectListView() {
                 minWidth: 150
             },{
                 field:'inBytes',
-                name:'Traffic (In/Out)',
+                name:'Traffic (In/Out) <br/> (Last 1 hr)',
                 minWidth:150,
                 formatter:function(r,c,v,cd,dc){
                     return contrail.format("{0} / {1}",formatBytes(dc['inBytes']),formatBytes(dc['outBytes']));
@@ -190,7 +190,10 @@ function ObjectListView() {
             obj['deferredObj'] = result['deferredObj'];
             obj['error'] = result['error'];
             obj['idField'] = 'uuid';
-            obj['isAsyncLoad'] = true;
+            obj['isAsyncLoad'] = false;
+            obj['dataSource'].onRowsChanged.subscribe(function(e,args){
+                dataSourceChangeHandler(obj['dataSource'],args,objectType,$.Deferred());
+            });
         } else if(objectType == 'project') {
             var projectDataSource = new ContrailDataView();
             if(globalObj['dataSources']['projectDS'] != null)
@@ -199,6 +202,13 @@ function ObjectListView() {
                 globalObj['dataSources']['projectDS'] = {dataSource:projectDataSource};
             var networkDS = new SingleDataSource('networkDS');
             var result = networkDS.getDataSourceObj();
+            result['dataSource'].onRowsChanged.subscribe(function(e,args){
+                var deferredObj = $.Deferred();
+                dataSourceChangeHandler(result['dataSource'],args,'network',deferredObj);
+                deferredObj.done(function(){
+                    objListView.refreshProjectSummaryGrid(result['dataSource']);
+                });
+            });
             var projData = getProjectData(result['dataSource'].getItems(),ifNull(globalObj['dataSources']['projectDS'],{}))['projectsData'];
             projectDataSource.setData(projData);
             //projectDataSource.pageSize(50); 
@@ -209,7 +219,7 @@ function ObjectListView() {
             obj['dataSource'] = projectDataSource;
             obj['deferredObj'] = result['deferredObj'];
             obj['error'] = result['error'];
-            obj['isAsyncLoad'] = true;
+            obj['isAsyncLoad'] = false;
         } else if(objectType == 'instance') { 
             var instCfilts = ['UveVirtualMachineAgent:interface_list','UveVirtualMachineAgent:vrouter',
                               'UveVirtualMachineAgent:fip_stats_list'];
@@ -220,10 +230,10 @@ function ObjectListView() {
                 obj['deferredObj'] = result['deferredObj'];
                 obj['error'] = result['error'];
                 obj['idField'] = 'name';
-                obj['isAsyncLoad'] = true;
+                obj['isAsyncLoad'] = false;
                 obj['dataSource'].onRowsChanged.subscribe(function(e,args){
-                    getStatsForVM(obj['dataSource'],ifNull(args,[]));
-                })
+                    dataSourceChangeHandler(obj['dataSource'],args,objectType,$.Deferred());
+                });
             } else if($.inArray(context,['project','network']) > -1) {
                 var contextType = context == 'project' ? 'project' : 'vn';
                 obj['transportCfg'] = { 
@@ -233,8 +243,8 @@ function ObjectListView() {
                             }
                 instanceDS = new ContrailDataView();
                 instanceDS.onRowsChanged.subscribe(function(e,args){
-                    getStatsForVM(obj['dataSource'],ifNull(args,[]));
-                })
+                    dataSourceChangeHandler(obj['dataSource'],args,objectType,$.Deferred());
+                });
                 //instDeferredObj is resolved when the instances tab of projects and the networks is clicked 
                 var instDeferredObj = $.Deferred();
                 //deferredObj is resolved when all instances are loaded, rejected if any ajax call fails
@@ -243,7 +253,7 @@ function ObjectListView() {
                                         loadedDeferredObj:loadedDeferredObj});
                 obj['dataSource'] = instanceDS;
                 obj['loadedDeferredObj'] = instDeferredObj;
-                obj['isAsyncLoad'] = true;
+                obj['isAsyncLoad'] = false;
                 //Passing the deferredObj to initGrid such that is hides loading icon in Grid/displays error message if ajax call fails
                 obj['deferredObj'] = loadedDeferredObj;
             }
@@ -699,7 +709,7 @@ function constructReqURL(obj) {
     if(obj['widget'] == 'flowseries') {
         $.extend(reqParams,{'sampleCnt':NUM_DATA_POINTS_FOR_FLOW_SERIES});
         //If useServerTime flag is true then the webserver timeStamps will be send in startTime and endTime to query engine
-        $.extend(reqParams,{'minsSince':30,'useServerTime':true});
+        $.extend(reqParams,{'minsSince':60,'useServerTime':true,'fip':obj['fip']});
     }
     //Don't append startTime/endTime if minsSince is provided as need to use realtive times 
     /*Always send the startTime and endTime instead of minsSince
@@ -771,11 +781,21 @@ var tenantNetworkMonitorUtils = {
         var retArr = $.map(ifNull(response['value'], response), function (currObj, idx) {
             currObj['rawData'] = $.extend(true,{},currObj);
             currObj['url'] = '/api/tenant/networking/virtual-network/summary?fqNameRegExp=' + currObj['name'];
-            currObj['inBytes'] = ifNull(jsonPath(currObj, '$..in_bytes')[0], 0);
-            currObj['outBytes'] = ifNull(jsonPath(currObj, '$..out_bytes')[0], 0);
+            currObj['outBytes'] = '-';
+            currObj['inBytes'] = '-';
+            var inBytes = 0,outBytes = 0;
+            var statsObj = getValueByJsonPath(currObj,'value;UveVirtualNetworkAgent;vn_stats;0;StatTable.UveVirtualNetworkAgent.vn_stats',[]);
+            for(var i = 0; i < statsObj.length; i++){
+                inBytes += ifNull(statsObj[i]['SUM(vn_stats.in_bytes)'],0);
+                outBytes += ifNull(statsObj[i]['SUM(vn_stats.out_bytes)'],0);
+            }
+            if(getValueByJsonPath(currObj,'value;UveVirtualNetworkAgent;vn_stats') != null) {
+                currObj['outBytes'] = outBytes;
+                currObj['inBytes'] = inBytes;
+            }
             currObj['instCnt'] = ifNull(jsonPath(currObj, '$..virtualmachine_list')[0], []).length;
-            currObj['inThroughput'] = ifNull(jsonPath(currObj, '$..in_bandwidth_usage')[0], 0);
-            currObj['outThroughput'] = ifNull(jsonPath(currObj, '$..out_bandwidth_usage')[0], 0);
+            currObj['inThroughput'] = ifNull(jsonPath(currObj, '$..in_bandwidth_usage')[0], '-');
+            currObj['outThroughput'] = ifNull(jsonPath(currObj, '$..out_bandwidth_usage')[0], '-');
             return currObj;
         });
         return retArr;
@@ -803,7 +823,7 @@ var tenantNetworkMonitorUtils = {
             obj['ip'] = ifNull(jsonPath(currObj, '$..interface_list[*].ip_address'), []);
             var floatingIPs = ifNull(jsonPath(currObj, '$..fip_stats_list')[0], []);
               obj['floatingIP'] = [];
-            if(intfStats.length > 0) {
+            if(getValueByJsonPath(currObj,'VirtualMachineStats;if_stats') != null) {
                 obj['inBytes'] = 0;
                 obj['outBytes'] = 0;
             }
@@ -1015,6 +1035,8 @@ var tenantNetworkMonitorUtils = {
         var instanes = ifNull(jsonPath(d,'$.UveVirtualNetworkAgent.virtualmachine_list')[0],[]);
         var ingressFlowCount = ifNull(jsonPath(d,'$.UveVirtualNetworkAgent.ingress_flow_count')[0],0);
         var egressFlowCount = ifNull(jsonPath(d,'$.UveVirtualNetworkAgent.egress_flow_count')[0],0);
+        var inBytes = ifNull(getValueByJsonPath(d,'UveVirtualNetworkAgent;in_bytes','-'));
+        var outBytes = ifNull(getValueByJsonPath(d,'UveVirtualNetworkAgent;out_bytes','-'));
         /*var flowCnt = ifNullOrEmptyObject(jsonPath(d,'$..flow_count')[0],0);
         //If flow count is reported from multiple vRouters,take the first one
         if(flowCnt instanceof Object)
@@ -1035,7 +1057,8 @@ var tenantNetworkMonitorUtils = {
         //retArr.push({lbl:'Instances',value:ifNull(jsonPath(d,'$..virtualmachine_list')[0],[]).length});
         retArr.push({lbl:'VRF',value:ifNullOrEmptyObject(jsonPath(d,'$..vrf_stats_list[0].name')[0],'')});
         retArr.push({lbl:'Policies',value:policyArr.join(', ')});
-        retArr.push({lbl:'Instances',value:instanes.join(', ')})
+        retArr.push({lbl:'Instances',value:instanes.join(', ')});
+        retArr.push({lbl:'Total Traffic(In/Out)',value:formatBytes(inBytes) +'/'+formatBytes(outBytes)});
         //Remove the label/values where value is empty
         retArr = $.map(retArr,function(obj,idx) {
             if(obj['value'] !== '')
@@ -1551,7 +1574,7 @@ function getVirtualNetworksData(deferredObj,dataSource,dsObj) {
     //var objType = ifNull(options['objType'],'');
     var vnCfilts = ['UveVirtualNetworkAgent:interface_list','UveVirtualNetworkAgent:in_bandwidth_usage','UveVirtualNetworkAgent:out_bandwidth_usage',
                 'UveVirtualNetworkAgent:in_bytes','UveVirtualNetworkAgent:out_bytes',//'UveVirtualNetworkAgent:in_stats','UveVirtualNetworkAgent:out_stats',
-                'UveVirtualNetworkConfig:connected_networks','UveVirtualNetworkAgent:virtualmachine_list'];
+                'UveVirtualNetworkConfig:connected_networks','UveVirtualNetworkAgent:virtualmachine_list']//,'UveVirtualNetworkAgent:vn_stats'];
     var obj = {};
     $.when($.ajax({
                 url:'/api/tenants/projects/default-domain',
@@ -1644,8 +1667,8 @@ function getProjectData(vnData,project){
         obj['y'] = obj['vnCnt'];
         obj['size'] = obj['throughput']+1;
         obj['type'] = 'network';
-        obj['inBytes']  = ifNull(jsonPath(d,'$..in_bytes')[0],0);
-        obj['outBytes'] = ifNull(jsonPath(d,'$..out_bytes')[0],0);
+        obj['inBytes'] = $.isNumeric(d['inBytes']) ? d['inBytes'] : 0;
+        obj['outBytes'] = $.isNumeric(d['outBytes']) ? d['outBytes'] : 0;
         vnArr.push(obj);
     });
     var vnCF = crossfilter(vnArr);
@@ -1666,8 +1689,16 @@ function getProjectData(vnData,project){
             projData[d['project']] = $.extend({},defProjObj);
         }
         //projData[d['project']]['uuid'] = projList[cfgIdx]['uuid'];
-        projData[d['project']]['inBytes'] += d['inBytes'];
+        /*if($.isNumeric(d['inBytes']) && $.isNumeric(projData[d['project']]['inBytes']))
+            projData[d['project']]['inBytes'] += d['inBytes'];
+        else
+            projData[d['project']]['inBytes'] = '-';
+        if($.isNumeric(d['outBytes']) && $.isNumeric(projData[d['project']]['outBytes']))
+            projData[d['project']]['outBytes'] += d['outBytes'];
+        else
+            projData[d['project']]['outBytes'] = '-';*/
         projData[d['project']]['outBytes'] += d['outBytes'];
+        projData[d['project']]['inBytes'] += d['inBytes'];
         projData[d['project']]['inThroughput'] += d['inThroughput'];
         projData[d['project']]['outThroughput'] += d['outThroughput'];
         projData[d['project']]['intfCnt'] += d['intfCnt'];
@@ -1706,8 +1737,8 @@ function getMultiValueStr(arr) {
 function getSelInstanceFromDropDown() {
     if($('#dropdownIP').length == 0)
         return {};
-    var vmIntfObj = $('#dropdownIP').data('contrailDropdown').getSelectedData()[0];
-    return {ip:vmIntfObj['ip_address'],vnName:vmIntfObj['virtual_network']};
+    return $('#dropdownIP').data('contrailDropdown').getSelectedData()[0];
+    
 }
 
 var connectedNetworkView = new connectedNetworkRenderer();
@@ -1721,8 +1752,8 @@ function connectedNetworkRenderer() {
       //Show Ingress/Egress Traffic in different colors
       data['stats'] = {
           'list' : [
-              { lbl : contrail.format('Ingress/Egress from {0} to {1}',obj['srcVN'].split(':').pop(),obj['fqName'].split(':').pop()),field:'toNetwork'},
-              { lbl : contrail.format('Egress/Ingress from {0} to {1}',obj['fqName'].split(':').pop(),obj['srcVN'].split(':').pop()),field:'fromNetwork'}
+              { lbl : contrail.format('Ingress/Egress from {0} to {1} (Last 1 hr)',obj['srcVN'].split(':').pop(),obj['fqName'].split(':').pop()),field:'toNetwork'},
+              { lbl : contrail.format('Egress/Ingress from {0} to {1} (Last 1 hr)',obj['fqName'].split(':').pop(),obj['srcVN'].split(':').pop()),field:'fromNetwork'}
           ],
           parseFn: function(response) {
               return [{
@@ -1748,36 +1779,46 @@ function connectedNetworkRenderer() {
  * This function gets the VM stats for the new VM's added to datasource and updates it 
  * and the deferredObj is resolved when all the VM stats are fetched
  */
-function getStatsForVM(dataSource,arguments,deferredObj) {
+function getStats(dataSource,arguments,type,deferredObj) {
     var updateRows = ifNull(arguments['rows'],[]);
-    if(isStatsPopulated(dataSource,updateRows)) {
-        var kfilt = $.map(updateRows,function(item){
-            return dataSource.getItemByIdx(item)['name'];
-        });
-        $.ajax({
-            url:'/api/tenant/get-data',
-            type:'POST',
-            data:{data:[{'type':'virtual-machine','kfilt':kfilt.join(',') ,'cfilt':'VirtualMachineStats'}]}
-        }).done(function(response){
-            var data = tenantNetworkMonitorUtils.instanceParseFn(response[0]);
-            var dataMap = {};
-            for(var i=0; i<data.length; i++){
-                var key = data[i]['name'];
-                dataMap[key] = data[i];
-            }
-            var dataItems = dataSource.getItems();
-            for(var i=0; i<dataItems.length; i++){
-                var obj = dataItems[i];
-                for(var j=0; j<kfilt.length; j++) {
-                    if(kfilt[j] == obj['name']) {
-                        obj['inBytes'] = ifNull(dataMap[kfilt[j]]['inBytes'],'-');
-                        obj['outBytes'] = ifNull(dataMap[kfilt[j]]['outBytes'],'-');
-                    }
+    var cfilt,parseFn,context,dataMap = {};
+    if (type == 'instance') {
+        cfilt = 'VirtualMachineStats';
+        parseFn = tenantNetworkMonitorUtils.instanceParseFn;
+        context = 'virtual-machine'; 
+    } else {
+        cfilt = 'UveVirtualNetworkAgent:vn_stats';
+        parseFn = tenantNetworkMonitorUtils.networkParseFn;
+        context = 'virtual-network'; 
+    }
+    var kfilt = $.map(updateRows,function(item){
+        return dataSource.getItemByIdx(item)['name'];
+    });
+    $.ajax({
+        url:'/api/tenant/get-data',
+        type:'POST',
+        data:{data:[{'type':context,'kfilt':kfilt.join(',') ,'cfilt':cfilt}]}
+    }).done(function(response){
+        var data = parseFn(response[0]);
+        for(var i=0; i<data.length; i++){
+            var key = data[i]['name'];
+            dataMap[key] = data[i];
+        }
+        var dataItems = dataSource.getItems();
+        for(var i=0; i<dataItems.length; i++){
+            var obj = dataItems[i];
+            for(var j=0; j<kfilt.length; j++) {
+                if(kfilt[j] == obj['name']) {
+                    var dataObj = ifNull(dataMap[kfilt[j]],{});
+                    obj['inBytes'] = ifNull(dataObj['inBytes'],'-');
+                    obj['outBytes'] = ifNull(dataObj['outBytes'],'-');
                 }
             }
-            dataSource.updateData(dataItems);
-        });
-    } 
+        }
+        dataSource.updateData(dataItems);
+        if(deferredObj != null)
+            deferredObj.resolve();
+    });
 }
 /* Function is to check whether stats column in the rows are updated,
  * by comparing with the default value of stats "-" to avoid 
@@ -1786,7 +1827,33 @@ function getStatsForVM(dataSource,arguments,deferredObj) {
 function isStatsPopulated(dataSource,updateRows){
     var dataItem = dataSource.getItemByIdx(updateRows[0]);
     if(dataItem['inBytes'] == '-') 
-        return true;
-    else
         return false;
+    else
+        return true;
+}
+
+/*
+ * This function is common dataSource change event handler for monitor network,project,instance summary pages
+ */
+function dataSourceChangeHandler(dataSource,args,type,deferredObj){
+    var grid = $('div.contrail-grid').data('contrailGrid');
+    var updateRows = ifNull(args['rows'],[]);
+    if(!isStatsPopulated(dataSource,updateRows)) {
+        getStats(dataSource,ifNull(args,[]),type,deferredObj);
+        if(grid != null)
+            grid.showGridLoading();
+        if(deferredObj != null) {
+            deferredObj.always(function(){
+                if(grid != null) {
+                    grid.removeGridLoading();
+                }
+            });
+        }
+    } else {
+        /*
+         * Resolving the deferredobj as there is no need to 
+         * call the getStats function
+         */
+        deferredObj.resolve();
+    }
 }

--- a/webroot/monitor/tenant-network/dashboard/ui/js/tenant_monitor_dashboard.js
+++ b/webroot/monitor/tenant-network/dashboard/ui/js/tenant_monitor_dashboard.js
@@ -19,6 +19,14 @@ function domainSummaryRenderer() {
         var renderDeferredObj = $.Deferred();
         var networkDS = new SingleDataSource('networkDS');
         var result = networkDS.getDataSourceObj();
+        result['dataSource'].onRowsChanged.subscribe(function(e,args){
+            var deferredObj = $.Deferred();
+            $('.icon-spinner').show();
+            dataSourceChangeHandler(result['dataSource'],ifNull(args,[]),'network',deferredObj);
+            deferredObj.done(function(){
+                $('.icon-spinner').hide();
+            });
+        });
         var dashboardData,callUpdateDashboard = false;
         cfg['loadedDeferredObj'] = result['deferredObj'];
         //Info: Create a renderDeferredObj (which will be resolved on getting first set of results) and pass it to initTemplates, 
@@ -52,8 +60,8 @@ function domainSummaryRenderer() {
         obj['title'] = contrail.format('Traffic Statistics for Domain ({0})',fqName);
         obj['widgetBoxId'] = 'traffic-stats';
         data['stats']['list'] = [
-            { lbl : 'Total Traffic In',field:'inBytes'},
-            { lbl : 'Total Traffic Out',field:'outBytes'}
+            { lbl : 'Total Traffic In (Last 1 hr)',field:'inBytes'},
+            { lbl : 'Total Traffic Out (Last 1 hr)',field:'outBytes'}
         ];
         data['charts']['chartType'] = 'bubble';
         data['charts']['colCount'] = 2;
@@ -105,10 +113,6 @@ function domainSummaryRenderer() {
         $(container).html(summaryTemplate(obj));
         startWidgetLoading(obj['widgetBoxId']);
         $(container).initTemplates(data);
-        cfg['loadedDeferredObj'].always(function(){
-            endWidgetLoading(obj['widgetBoxId']);
-            $('.icon-spinner').hide();
-        });
         cfg['loadedDeferredObj'].fail(function(errObj){
             renderDeferredObj.reject(errObj);
         });

--- a/webroot/monitor/tenant-network/jobs/network.mon.jobs.js
+++ b/webroot/monitor/tenant-network/jobs/network.mon.jobs.js
@@ -1028,14 +1028,9 @@ function doConcatArr (data)
 function processVNFlowSeriesData (pubChannel, saveChannelKey, jobData, done)
 {
     var appData = jobData.taskData.appData;
-    var srcVNObjArr = [];
-    var destVNObjArr = [];
     var vnName = appData['srcVN'];
-    var srcWhereClause = [
-        {'sourcevn':vnName}
-    ];
-    var destWhereClause = [
-        {'destvn':vnName}
+    var whereClause = [
+        {'name':vnName}
     ];
     var minsSince = appData.minsSince;
     var timeObj;
@@ -1052,19 +1047,19 @@ function processVNFlowSeriesData (pubChannel, saveChannelKey, jobData, done)
         timeGran = appData['timeGran'];
     }
     var strTimeGran = 'T=' + timeGran;
-    var srcSelectArr = ['sum(bytes)', 'sum(packets)', strTimeGran, 'sourcevn'];
-    var destSelectArr = ['sum(bytes)', 'sum(packets)', strTimeGran, 'destvn'];
-
-    var srcQueryJSON = formatQueryString('FlowSeriesTable', srcWhereClause,
-        srcSelectArr, timeObj, true, null);
-    var destQueryJSON = formatQueryString('FlowSeriesTable', destWhereClause,
-        destSelectArr, timeObj, true, null);
-    formatFlowSeriesQuery(srcQueryJSON);
-    formatFlowSeriesQuery(destQueryJSON);
+    var selectArr = ['SUM(vn_stats.out_bytes)', 'SUM(vn_stats.out_tpkts)','SUM(vn_stats.in_bytes)',
+                       'SUM(vn_stats.in_tpkts)', strTimeGran, 'name'];
+    var queryJSON = formatQueryString('StatTable_UveVirtualNetworkAgent_vn_stats', whereClause,
+            selectArr, timeObj, true, null);
+    //Removing the flow_count select field from query as not required for the OracleStats 
+    var flowCountIdx = queryJSON['select_fields'].indexOf('flow_count');
+    if (flowCountIdx > -1)
+        queryJSON['select_fields'].splice(flowCountIdx,1);
+    formatFlowSeriesQuery(queryJSON);
     logutils.logger.debug(messages.qe.qe_execution + 'VN Flow Series data ' +
         vnName);
-    flowCache.getFlowSeriesData('vn', appData, srcQueryJSON, destQueryJSON,
-        commonUtils.doEnsureExecution(function(err, data) {
+    flowCache.getFlowSeriesData('vn', appData, queryJSON, null,
+            commonUtils.doEnsureExecution(function(err, data) {
             if (data != null) {
                 resultJSON = data;
             } else {
@@ -1075,23 +1070,17 @@ function processVNFlowSeriesData (pubChannel, saveChannelKey, jobData, done)
                 JSON.stringify(resultJSON),
                 JSON.stringify(resultJSON),
                 0, 0, done);
-        }, global.DEFAULT_MIDDLEWARE_API_TIMEOUT));
+        }, global.DEFAULT_MIDDLEWARE_API_TIMEOUT),global.STAT_TYPE);
 }
 
 function processVNsFlowSeriesData (pubChannel, saveChannelKey, jobData, done)
 {
     var appData = jobData.taskData.appData;
-    var srcVNObjArr = [];
-    var destVNObjArr = [];
     var srcVN = appData['srcVN'];
     var dstVN = appData['dstVN'];
-    var srcWhereClause = [
-        {'sourcevn':srcVN},
-        {'destvn':dstVN}
-    ];
-    var destWhereClause = [
-        {'sourcevn':dstVN},
-        {'destvn':srcVN}
+    var whereClause = [
+        {'name':srcVN},
+        {'vn_stats.other_vn':dstVN}
     ];
     var minsSince = appData['minsSince'];
     var timeObj;
@@ -1107,18 +1096,19 @@ function processVNsFlowSeriesData (pubChannel, saveChannelKey, jobData, done)
         timeGran = appData['timeGran'];
     }
     var strTimeGran = 'T=' + timeGran;
-    var srcSelectArr = ['sum(bytes)', 'sum(packets)', strTimeGran, 'sourcevn', 'destvn'];
-    var destSelectArr = ['sum(bytes)', 'sum(packets)', strTimeGran, 'sourcevn', 'destvn'];
+    var selectArr = ['SUM(vn_stats.out_bytes)', 'SUM(vn_stats.out_tpkts)','SUM(vn_stats.in_bytes)',
+                        'SUM(vn_stats.in_tpkts)', strTimeGran, 'name', 'vn_stats.other_vn'];
 
-    var srcQueryJSON = formatQueryString('FlowSeriesTable', srcWhereClause,
-        srcSelectArr, timeObj, true, null, 1, true);
-    var destQueryJSON = formatQueryString('FlowSeriesTable', destWhereClause,
-        destSelectArr, timeObj, true, null, 1, true);
-    formatFlowSeriesQuery(srcQueryJSON);
-    formatFlowSeriesQuery(destQueryJSON);
+    var queryJSON = formatQueryString('StatTable_UveVirtualNetworkAgent_vn_stats', whereClause,
+            selectArr, timeObj, true, null, 1, true);
+  //Removing the flow_count select field from query as not required for the OracleStats 
+    var flowCountIdx = queryJSON['select_fields'].indexOf('flow_count');
+    if (flowCountIdx > -1)
+        queryJSON['select_fields'].splice(flowCountIdx,1);
+    formatFlowSeriesQuery(queryJSON);
     logutils.logger.debug(messages.qe.qe_execution + 'Connected VNs Flow Series data ' +
         srcVN + ' ' + dstVN);
-    flowCache.getFlowSeriesData('conn-vn', appData, srcQueryJSON, destQueryJSON,
+    flowCache.getFlowSeriesData('conn-vn', appData, queryJSON, null,
         function (err, data) {
             if (data != null) {
                 resultJSON = data;
@@ -1130,7 +1120,7 @@ function processVNsFlowSeriesData (pubChannel, saveChannelKey, jobData, done)
                 JSON.stringify(resultJSON),
                 JSON.stringify(resultJSON),
                 0, 0, done);
-        });
+        },global.STAT_TYPE);
 }
 
 function processTopNwDetailsByProject (pubChannel, saveChannelKey, jobData, done)
@@ -1575,15 +1565,14 @@ function processVMFlowSeriesData (pubChannel, saveChannelKey, jobData, done)
     var appData = jobData.taskData.appData;
     var srcVNObjArr = [];
     var destVNObjArr = [];
-    var vnName = appData['vnName'];
+    var vnName = appData['vName'];
+    var vmName = appData['vmName'];
+    var vmVnName = appData['vmVnName'];
+    var fip = appData['fip'];
     var ip = appData.ip;
-    var srcWhereClause = [
-        {'sourcevn':vnName},
-        {'sourceip':ip}
-    ];
-    var destWhereClause = [
-        {'destvn':vnName},
-        {'destip':ip}
+    var context = 'vm';
+    var whereClause = [
+        {'if_stats.name':vmVnName}
     ];
     var minsSince = appData['minsSince'];
     var timeObj;
@@ -1601,20 +1590,27 @@ function processVMFlowSeriesData (pubChannel, saveChannelKey, jobData, done)
         timeGran = appData['timeGran'];
     }
     var strTimeGran = 'T=' + timeGran;
-    var srcSelectArr = ['sum(bytes)', 'sum(packets)', strTimeGran, 'sourcevn'];
-    var destSelectArr = ['sum(bytes)', 'sum(packets)', strTimeGran, 'destvn'];
-
-    var srcQueryJSON = formatQueryString('FlowSeriesTable', srcWhereClause,
-        srcSelectArr, timeObj, true, null,
+    var table = 'StatTable_VirtualMachineStats_if_stats';
+    var selectArr = ['SUM(if_stats.out_bytes)', 'SUM(if_stats.in_bytes)','SUM(if_stats.out_pkts)','SUM(if_stats.in_pkts)', strTimeGran, 'name'];
+    if(fip) {
+        table = 'StatTable_VirtualMachineStats_fip_stats';
+        selectArr = ['SUM(fip_stats.out_bytes)', 'SUM(fip_stats.in_bytes)','SUM(fip_stats.out_pkts)','SUM(fip_stats.in_pkts)', strTimeGran, 'name'];
+        whereClause = [
+                       {'fip_stats.ip_address':ip}
+        ];
+        context = 'fip';
+    }
+    var queryJSON = formatQueryString(table, whereClause,
+            selectArr, timeObj, true, null,
         global.TRAFFIC_DIR_INGRESS, true);
-    var destQueryJSON = formatQueryString('FlowSeriesTable', destWhereClause,
-        destSelectArr, timeObj, true, null,
-        global.TRAFFIC_DIR_INGRESS, true);
-    formatFlowSeriesQuery(srcQueryJSON);
-    formatFlowSeriesQuery(destQueryJSON);
+    //Removing the flow_count select field from query as not required for the OracleStats 
+    var flowCountIdx = queryJSON['select_fields'].indexOf('flow_count');
+    if (flowCountIdx > -1)
+        queryJSON['select_fields'].splice(flowCountIdx,1);
+    formatFlowSeriesQuery(queryJSON);
     logutils.logger.debug(messages.qe.qe_execution + 'VM Flow Series data ' +
         vnName);
-    flowCache.getFlowSeriesData('vm', appData, srcQueryJSON, destQueryJSON,
+    flowCache.getFlowSeriesData(context, appData, queryJSON, null,
         function (err, data) {
             if (data != null) {
                 resultJSON = data;
@@ -1626,7 +1622,7 @@ function processVMFlowSeriesData (pubChannel, saveChannelKey, jobData, done)
                 JSON.stringify(resultJSON),
                 JSON.stringify(resultJSON),
                 0, 0, done);
-        });
+        },global.STAT_TYPE);
 }
 
 function parseVMStats (resultJSON, data)


### PR DESCRIPTION
- Flowseries charts in VirtualMachine, Virtual Network details page and the Inter VN stats page(When we click on the links in the topology)
- Earlier the time series charts are with 7 secs granularity and past 30mins now it is 30 secs granularity and past one hour data
- Earlier two queries were issuing for the IN & Out stats now we are getting in same query
- Added the last 1 hr tag where ever we are displaying the last one hour stats
  Conflicts:
  webroot/monitor/tenant-network/instance/ui/js/tenant_monitor_instance.js

Change-Id: I70f7c366a032915f17025062bba89da1afb9b276
